### PR TITLE
Makefile: Mac-compatible rpath flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ CXXFLAGS	= $(CFLAGS) -std=c++14
 
 ASFLAGS	:=	$(ARCH)
 LDFLAGS	:=	`pkg-config --libs sdl2` \
-			-Wl,-rpath=. 
+			-Wl,-rpath . 
 
 ifeq ($(DEBUG),1)
   CFLAGS  += -O0 -g


### PR DESCRIPTION
Mac's `ld` doesn't support an `=` between `-rpath` and the argument.

I haven't been able to test on Windows or Linux to make sure it's still compatible there, but it fixes it on Mac.